### PR TITLE
fix: return validation failed instead of reverting

### DIFF
--- a/contracts/SmartSession.sol
+++ b/contracts/SmartSession.sol
@@ -250,19 +250,6 @@ contract SmartSession is ISmartSession, SmartSessionBase, SmartSessionERC7739 {
         if (!$enabledSessions.contains({ account: account, value: PermissionId.unwrap(permissionId) })) {
             revert InvalidPermissionId(permissionId);
         }
-        /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
-        /*                 Check SessionKey ISessionValidator         */
-        /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
-
-        // Validate the session key signature
-        if (
-            !$sessionValidators.isValidISessionValidator({
-                hash: userOpHash,
-                account: account,
-                permissionId: permissionId,
-                signature: decompressedSignature
-            })
-        ) return ERC4337_VALIDATION_FAILED;
 
         /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
         /*                    Check UserOp Policies                   */
@@ -350,6 +337,18 @@ contract SmartSession is ISmartSession, SmartSessionBase, SmartSessionERC7739 {
                 minPolicies: 1
             });
         }
+
+        /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+        /*                 Check SessionKey ISessionValidator         */
+        /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+        if (
+            !$sessionValidators.isValidISessionValidator({
+                hash: userOpHash,
+                account: account,
+                permissionId: permissionId,
+                signature: decompressedSignature
+            })
+        ) return ERC4337_VALIDATION_FAILED;
     }
 
     function isValidSignatureWithSender(

--- a/contracts/SmartSession.sol
+++ b/contracts/SmartSession.sol
@@ -255,13 +255,14 @@ contract SmartSession is ISmartSession, SmartSessionBase, SmartSessionERC7739 {
         /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
         // Validate the session key signature
-        // this call reverts if the ISessionValidator is not set or signature is invalid
-        $sessionValidators.requireValidISessionValidator({
-            userOpHash: userOpHash,
-            account: account,
-            permissionId: permissionId,
-            signature: decompressedSignature
-        });
+        if (
+            !$sessionValidators.isValidISessionValidator({
+                hash: userOpHash,
+                account: account,
+                permissionId: permissionId,
+                signature: decompressedSignature
+            })
+        ) return ERC4337_VALIDATION_FAILED;
 
         /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
         /*                    Check UserOp Policies                   */

--- a/contracts/lib/SignerLib.sol
+++ b/contracts/lib/SignerLib.sol
@@ -14,30 +14,6 @@ library SignerLib {
         PermissionId permissionId, ISessionValidator sessionValidator, address account, bytes32 userOpHash
     );
 
-    function requireValidISessionValidator(
-        mapping(PermissionId => mapping(address => SignerConf)) storage $sessionValidators,
-        bytes32 userOpHash,
-        address account,
-        PermissionId permissionId,
-        bytes memory signature
-    )
-        internal
-        view
-    {
-        ISessionValidator sessionValidator = $sessionValidators[permissionId][account].sessionValidator;
-        if (address(sessionValidator) == address(0)) revert SignerNotFound(permissionId, account);
-
-        // check signature of ISessionValidator first.
-        // policies only need to be processed if the signature is correct
-        if (
-            sessionValidator.validateSignatureWithData({
-                hash: userOpHash,
-                sig: signature,
-                data: $sessionValidators[permissionId][account].config.load()
-            }) == false
-        ) revert InvalidSessionKeySignature(permissionId, sessionValidator, account, userOpHash);
-    }
-
     function isValidISessionValidator(
         mapping(PermissionId => mapping(address => SignerConf)) storage $sessionValidators,
         bytes32 hash,


### PR DESCRIPTION
Upon karandeep's request, I changed this to return failed, rather than reverting.

Im wondering, if having the signature check BEFORE the policy checks is creating an issue for gas estimations.

should we move the sig check to the very last step? 