### PR TITLE
Fix Fallback to use Account data instead of Module eip712 domain

### DIFF
--- a/contracts/SmartSessionCompatibilityFallback.sol
+++ b/contracts/SmartSessionCompatibilityFallback.sol
@@ -57,7 +57,7 @@ contract SmartSessionCompatibilityFallback is ERC7579FallbackBase {
             uint256[] memory extensions
         )
     {
-        
+        fields = hex"0f"; // 01111  
         verifyingContract = msg.sender;
 
         // follows "vendorname.accountname.semver" structure as per ERC-7579

--- a/contracts/SmartSessionCompatibilityFallback.sol
+++ b/contracts/SmartSessionCompatibilityFallback.sol
@@ -67,6 +67,5 @@ contract SmartSessionCompatibilityFallback is ERC7579FallbackBase {
         (name, version) = accountId.parseAccountId();
 
         chainId = block.chainid;
-
     }
 }

--- a/contracts/core/SmartSessionERC7739.sol
+++ b/contracts/core/SmartSessionERC7739.sol
@@ -6,7 +6,7 @@ import { ISmartSession } from "../ISmartSession.sol";
 
 /// @notice ERC1271 mixin with nested EIP-712 approach.
 /// @author Solady (https://github.com/vectorized/solady/blob/main/src/accounts/ERC1271.sol)
-abstract contract SmartSessionERC7739 is ISmartSession, EIP712 {
+abstract contract SmartSessionERC7739 is ISmartSession {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                         CONSTANTS                          */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
@@ -206,7 +206,7 @@ abstract contract SmartSessionERC7739 is ISmartSession, EIP712 {
             }
             mstore(0x40, m) // Restore the free memory pointer.
         }
-        if (t == bytes32(0)) hash = _hashTypedData(hash); // `PersonalSign` workflow.
+        if (t == bytes32(0)) return false; // `PersonalSign` workflow is not supported.
         result = _erc1271IsValidSignatureNowCalldata(sender, hash, signature, contents);
     }
 
@@ -220,7 +220,7 @@ abstract contract SmartSessionERC7739 is ISmartSession, EIP712 {
             address verifyingContract,
             bytes32 salt,
             uint256[] memory extensions
-        ) = eip712Domain();
+        ) = EIP712(msg.sender).eip712Domain();
         /// @solidity memory-safe-assembly
         assembly {
             m := mload(0x40) // Grab the free memory pointer.
@@ -236,7 +236,4 @@ abstract contract SmartSessionERC7739 is ISmartSession, EIP712 {
         }
     }
 
-    function _domainNameAndVersion() internal pure override returns (string memory, string memory) {
-        return ("SmartSession", "1");
-    }
 }

--- a/contracts/lib/AccountIdLib.sol
+++ b/contracts/lib/AccountIdLib.sol
@@ -13,12 +13,10 @@ library AccountIdLib {
     function parseAccountId(string memory id) internal pure returns (string memory name, string memory version) {
         strings.slice memory id = id.toSlice();
         strings.slice memory delim = ".".toSlice();
-        string[] memory parts = new string[](id.count(delim) + 1); 
-        for(uint i = 0; i < parts.length; i++) {
-            parts[i] = id.split(delim).toString();
-        }
-        name = string(abi.encodePacked(parts[0], " ", parts[1]));
-        version = parts[2];
+        string memory vendor = id.split(delim).toString();
+        string memory account = id.split(delim).toString();
+        name = string(abi.encodePacked(vendor, " ", account));
+        version = id.toString();
         console2.log("name: ", name);
         console2.log("version: ", version);
     }

--- a/contracts/lib/AccountIdLib.sol
+++ b/contracts/lib/AccountIdLib.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.25;
 import { strings } from "stringutils/strings.sol";
 
-import "forge-std/console2.sol";
-
 library AccountIdLib {
 
     using strings for *;
@@ -13,11 +11,7 @@ library AccountIdLib {
     function parseAccountId(string memory id) internal pure returns (string memory name, string memory version) {
         strings.slice memory id = id.toSlice();
         strings.slice memory delim = ".".toSlice();
-        string memory vendor = id.split(delim).toString();
-        string memory account = id.split(delim).toString();
-        name = string(abi.encodePacked(vendor, " ", account));
+        name = string(abi.encodePacked(id.split(delim).toString(), " ", id.split(delim).toString()));
         version = id.toString();
-        console2.log("name: ", name);
-        console2.log("version: ", version);
     }
 }

--- a/contracts/lib/AccountIdLib.sol
+++ b/contracts/lib/AccountIdLib.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.25;
+import { strings } from "stringutils/strings.sol";
+
+import "forge-std/console2.sol";
+
+library AccountIdLib {
+
+    using strings for *;
+    
+    // id follows "vendorname.accountname.semver" structure as per ERC-7579
+    // use this for parsing the full account name and version as strings
+    function parseAccountId(string memory id) internal pure returns (string memory name, string memory version) {
+        strings.slice memory id = id.toSlice();
+        strings.slice memory delim = ".".toSlice();
+        string[] memory parts = new string[](id.count(delim) + 1); 
+        for(uint i = 0; i < parts.length; i++) {
+            parts[i] = id.split(delim).toString();
+        }
+        name = string(abi.encodePacked(parts[0], " ", parts[1]));
+        version = parts[2];
+        console2.log("name: ", name);
+        console2.log("version: ", version);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "@rhinestone/modulekit": "^0.4.10",
     "freshcryptolib": "github:rdubois-crypto/FreshCryptoLib",
     "solmate": "github:transmissions11/solmate",
-    "@rhinestone/flatbytes": "github:rhinestonewtf/flatbytes"
+    "@rhinestone/flatbytes": "github:rhinestonewtf/flatbytes",
+    "stringutils": "github:Arachnid/solidity-stringutils"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.2",
@@ -56,5 +57,6 @@
   ],
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "packageManager": "pnpm@9.0.5+sha1.6db99351548f394a1d96aa1de98dec032aef8823"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,10 +16,13 @@ importers:
         version: 0.4.10(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))(typescript@4.9.5)
       freshcryptolib:
         specifier: github:rdubois-crypto/FreshCryptoLib
-        version: FreshCryptoLib@https://codeload.github.com/rdubois-crypto/FreshCryptoLib/tar.gz/be47b0472ac1d7c78e68d31086399cc8bafe1b5b
+        version: FreshCryptoLib@https://codeload.github.com/rdubois-crypto/FreshCryptoLib/tar.gz/8179e08cac72072bd260796633fec41fdfd5b441
       solmate:
         specifier: github:transmissions11/solmate
         version: https://codeload.github.com/transmissions11/solmate/tar.gz/97bdb2003b70382996a79a406813f76417b1cf90
+      stringutils:
+        specifier: github:Arachnid/solidity-stringutils
+        version: solidity-stringutils@https://codeload.github.com/Arachnid/solidity-stringutils/tar.gz/4b2fcc43fa0426e19ce88b1f1ec16f5903a2e461
     devDependencies:
       '@changesets/cli':
         specifier: ^2.27.2
@@ -517,20 +520,20 @@ packages:
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
 
-  FreshCryptoLib@https://codeload.github.com/rdubois-crypto/FreshCryptoLib/tar.gz/be47b0472ac1d7c78e68d31086399cc8bafe1b5b:
-    resolution: {tarball: https://codeload.github.com/rdubois-crypto/FreshCryptoLib/tar.gz/be47b0472ac1d7c78e68d31086399cc8bafe1b5b}
+  FreshCryptoLib@https://codeload.github.com/rdubois-crypto/FreshCryptoLib/tar.gz/8179e08cac72072bd260796633fec41fdfd5b441:
+    resolution: {tarball: https://codeload.github.com/rdubois-crypto/FreshCryptoLib/tar.gz/8179e08cac72072bd260796633fec41fdfd5b441}
     version: 0.0.0
 
   abbrev@1.0.9:
     resolution: {integrity: sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==}
 
+  accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/6f02f5a28a20e804d0410b4b5b570dd4b076dcf9:
+    resolution: {tarball: https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/6f02f5a28a20e804d0410b4b5b570dd4b076dcf9}
+    version: 0.7.0
+
   accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6:
     resolution: {tarball: https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6}
     version: 0.6.0
-
-  accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/f1c5c11b273b7ddae26bb20809419b33ccb8f043:
-    resolution: {tarball: https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/f1c5c11b273b7ddae26bb20809419b33ccb8f043}
-    version: 0.7.0
 
   accountabstraction@https://codeload.github.com/kopy-kat/account-abstraction/tar.gz/c5887153fbfe3ed09b2637cac39873f96d676f38:
     resolution: {tarball: https://codeload.github.com/kopy-kat/account-abstraction/tar.gz/c5887153fbfe3ed09b2637cac39873f96d676f38}
@@ -1063,8 +1066,8 @@ packages:
       debug:
         optional: true
 
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf6606142994b1e47e2882ce0cd477c020d77623:
-    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf6606142994b1e47e2882ce0cd477c020d77623}
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/1ce7535a517406b9aec7ea1ea27c1b41376f712c:
+    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1ce7535a517406b9aec7ea1ea27c1b41376f712c}
     version: 1.9.2
 
   form-data-encoder@2.1.4:
@@ -1899,9 +1902,9 @@ packages:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
-  solady@https://codeload.github.com/vectorized/solady/tar.gz/f74d6b6cec7e5f72f57949dfa5d51b632bcc29a6:
-    resolution: {tarball: https://codeload.github.com/vectorized/solady/tar.gz/f74d6b6cec7e5f72f57949dfa5d51b632bcc29a6}
-    version: 0.0.235
+  solady@https://codeload.github.com/vectorized/solady/tar.gz/f833eadd4591da7e8e455eab779bf1d918486847:
+    resolution: {tarball: https://codeload.github.com/vectorized/solady/tar.gz/f833eadd4591da7e8e455eab779bf1d918486847}
+    version: 0.0.237
 
   solarray@https://codeload.github.com/sablier-labs/solarray/tar.gz/6bf10cb34cdace52a3ba5fe437e78cc82df92684:
     resolution: {tarball: https://codeload.github.com/sablier-labs/solarray/tar.gz/6bf10cb34cdace52a3ba5fe437e78cc82df92684}
@@ -1925,6 +1928,10 @@ packages:
     hasBin: true
     peerDependencies:
       hardhat: ^2.11.0
+
+  solidity-stringutils@https://codeload.github.com/Arachnid/solidity-stringutils/tar.gz/4b2fcc43fa0426e19ce88b1f1ec16f5903a2e461:
+    resolution: {tarball: https://codeload.github.com/Arachnid/solidity-stringutils/tar.gz/4b2fcc43fa0426e19ce88b1f1ec16f5903a2e461}
+    version: 0.0.0
 
   solmate@https://codeload.github.com/transmissions11/solmate/tar.gz/97bdb2003b70382996a79a406813f76417b1cf90:
     resolution: {tarball: https://codeload.github.com/transmissions11/solmate/tar.gz/97bdb2003b70382996a79a406813f76417b1cf90}
@@ -2812,8 +2819,8 @@ snapshots:
 
   '@rhinestone/checknsignatures@https://codeload.github.com/rhinestonewtf/checknsignatures/tar.gz/7ff44ef46da1266374e6a98e6cf69d727d7c357d':
     dependencies:
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf6606142994b1e47e2882ce0cd477c020d77623
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/f74d6b6cec7e5f72f57949dfa5d51b632bcc29a6
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1ce7535a517406b9aec7ea1ea27c1b41376f712c
+      solady: https://codeload.github.com/vectorized/solady/tar.gz/f833eadd4591da7e8e455eab779bf1d918486847
 
   '@rhinestone/erc4337-validation@0.0.1-alpha.2(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))(typescript@4.9.5)':
     dependencies:
@@ -2821,9 +2828,9 @@ snapshots:
       account-abstraction: accountabstraction@https://codeload.github.com/kopy-kat/account-abstraction/tar.gz/c5887153fbfe3ed09b2637cac39873f96d676f38(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       account-abstraction-v0.6: accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf6606142994b1e47e2882ce0cd477c020d77623
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1ce7535a517406b9aec7ea1ea27c1b41376f712c
       prettier: 2.8.8
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/f74d6b6cec7e5f72f57949dfa5d51b632bcc29a6
+      solady: https://codeload.github.com/vectorized/solady/tar.gz/f833eadd4591da7e8e455eab779bf1d918486847
       solhint: 4.5.4(typescript@4.9.5)
     transitivePeerDependencies:
       - bufferutil
@@ -2842,9 +2849,9 @@ snapshots:
       account-abstraction: accountabstraction@https://codeload.github.com/kopy-kat/account-abstraction/tar.gz/c5887153fbfe3ed09b2637cac39873f96d676f38(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       account-abstraction-v0.6: accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf6606142994b1e47e2882ce0cd477c020d77623
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1ce7535a517406b9aec7ea1ea27c1b41376f712c
       prettier: 2.8.8
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/f74d6b6cec7e5f72f57949dfa5d51b632bcc29a6
+      solady: https://codeload.github.com/vectorized/solady/tar.gz/f833eadd4591da7e8e455eab779bf1d918486847
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -2857,13 +2864,13 @@ snapshots:
 
   '@rhinestone/flatbytes@https://codeload.github.com/rhinestonewtf/flatbytes/tar.gz/bb0859e85ef2213d08d6280c8af9a7da4596b30f':
     dependencies:
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf6606142994b1e47e2882ce0cd477c020d77623
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1ce7535a517406b9aec7ea1ea27c1b41376f712c
 
   '@rhinestone/module-bases@https://codeload.github.com/rhinestonewtf/module-bases/tar.gz/2db71722f939ed7d76315fc94c1a85bcb09ce59b(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))':
     dependencies:
       '@ERC4337/account-abstraction': accountabstraction@https://codeload.github.com/kopy-kat/account-abstraction/tar.gz/c5887153fbfe3ed09b2637cac39873f96d676f38(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       erc7579: erc7579-implementation@https://codeload.github.com/erc7579/erc7579-implementation/tar.gz/b3f8bcb2df3aae3217213ffa8b7a87c1eb42ec56(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf6606142994b1e47e2882ce0cd477c020d77623
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1ce7535a517406b9aec7ea1ea27c1b41376f712c
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -2888,8 +2895,8 @@ snapshots:
       ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
       erc7579: erc7579-implementation@https://codeload.github.com/erc7579/erc7579-implementation/tar.gz/b3f8bcb2df3aae3217213ffa8b7a87c1eb42ec56(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       excessively-safe-call: '@nomad-xyz/excessively-safe-call@https://codeload.github.com/nomad-xyz/ExcessivelySafeCall/tar.gz/81cd99ce3e69117d665d7601c330ea03b97acce0'
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf6606142994b1e47e2882ce0cd477c020d77623
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/f74d6b6cec7e5f72f57949dfa5d51b632bcc29a6
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1ce7535a517406b9aec7ea1ea27c1b41376f712c
+      solady: https://codeload.github.com/vectorized/solady/tar.gz/f833eadd4591da7e8e455eab779bf1d918486847
       solarray: https://codeload.github.com/sablier-labs/solarray/tar.gz/6bf10cb34cdace52a3ba5fe437e78cc82df92684
     transitivePeerDependencies:
       - bufferutil
@@ -2913,8 +2920,8 @@ snapshots:
       '@safe-global/safe-contracts': 1.4.1(ethers@5.7.2)
       ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
       erc7579: erc7579-implementation@https://codeload.github.com/erc7579/erc7579-implementation/tar.gz/b3f8bcb2df3aae3217213ffa8b7a87c1eb42ec56(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf6606142994b1e47e2882ce0cd477c020d77623
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/f74d6b6cec7e5f72f57949dfa5d51b632bcc29a6
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1ce7535a517406b9aec7ea1ea27c1b41376f712c
+      solady: https://codeload.github.com/vectorized/solady/tar.gz/f833eadd4591da7e8e455eab779bf1d918486847
       solarray: https://codeload.github.com/sablier-labs/solarray/tar.gz/6bf10cb34cdace52a3ba5fe437e78cc82df92684
     transitivePeerDependencies:
       - bufferutil
@@ -2929,7 +2936,7 @@ snapshots:
 
   '@rhinestone/sentinellist@https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/67e42f0eb3cf355ddba5a017892f9cc28d924875':
     dependencies:
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf6606142994b1e47e2882ce0cd477c020d77623
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1ce7535a517406b9aec7ea1ea27c1b41376f712c
 
   '@safe-global/safe-contracts@1.4.1(ethers@5.7.2)':
     dependencies:
@@ -3082,18 +3089,19 @@ snapshots:
 
   '@types/semver@7.5.8': {}
 
-  FreshCryptoLib@https://codeload.github.com/rdubois-crypto/FreshCryptoLib/tar.gz/be47b0472ac1d7c78e68d31086399cc8bafe1b5b: {}
+  FreshCryptoLib@https://codeload.github.com/rdubois-crypto/FreshCryptoLib/tar.gz/8179e08cac72072bd260796633fec41fdfd5b441: {}
 
   abbrev@1.0.9: {}
 
-  accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5)):
+  accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/6f02f5a28a20e804d0410b4b5b570dd4b076dcf9(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5)):
     dependencies:
-      '@gnosis.pm/safe-contracts': 1.3.0(ethers@5.7.2)
       '@nomiclabs/hardhat-etherscan': 2.1.8(hardhat@2.22.9(typescript@4.9.5))
-      '@openzeppelin/contracts': 4.9.6
+      '@openzeppelin/contracts': 5.0.2
       '@thehubbleproject/bls': 0.5.1
       '@typechain/hardhat': 2.3.1(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
+      '@types/debug': 4.1.12
       '@types/mocha': 9.1.1
+      debug: 4.3.6(supports-color@8.1.1)
       ethereumjs-util: 7.1.5
       ethereumjs-wallet: 1.0.2
       hardhat-deploy: 0.11.45
@@ -3112,15 +3120,14 @@ snapshots:
       - typechain
       - utf-8-validate
 
-  accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/f1c5c11b273b7ddae26bb20809419b33ccb8f043(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5)):
+  accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5)):
     dependencies:
+      '@gnosis.pm/safe-contracts': 1.3.0(ethers@5.7.2)
       '@nomiclabs/hardhat-etherscan': 2.1.8(hardhat@2.22.9(typescript@4.9.5))
-      '@openzeppelin/contracts': 5.0.2
+      '@openzeppelin/contracts': 4.9.6
       '@thehubbleproject/bls': 0.5.1
       '@typechain/hardhat': 2.3.1(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      '@types/debug': 4.1.12
       '@types/mocha': 9.1.1
-      debug: 4.3.6(supports-color@8.1.1)
       ethereumjs-util: 7.1.5
       ethereumjs-wallet: 1.0.2
       hardhat-deploy: 0.11.45
@@ -3556,10 +3563,10 @@ snapshots:
   erc7579-implementation@https://codeload.github.com/erc7579/erc7579-implementation/tar.gz/b3f8bcb2df3aae3217213ffa8b7a87c1eb42ec56(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5)):
     dependencies:
       '@rhinestone/sentinellist': https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/67e42f0eb3cf355ddba5a017892f9cc28d924875
-      account-abstraction: accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/f1c5c11b273b7ddae26bb20809419b33ccb8f043(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
+      account-abstraction: accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/6f02f5a28a20e804d0410b4b5b570dd4b076dcf9(ethers@5.7.2)(hardhat@2.22.9(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf6606142994b1e47e2882ce0cd477c020d77623
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/f74d6b6cec7e5f72f57949dfa5d51b632bcc29a6
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1ce7535a517406b9aec7ea1ea27c1b41376f712c
+      solady: https://codeload.github.com/vectorized/solady/tar.gz/f833eadd4591da7e8e455eab779bf1d918486847
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -3792,7 +3799,7 @@ snapshots:
     optionalDependencies:
       debug: 4.3.6(supports-color@8.1.1)
 
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf6606142994b1e47e2882ce0cd477c020d77623: {}
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/1ce7535a517406b9aec7ea1ea27c1b41376f712c: {}
 
   form-data-encoder@2.1.4: {}
 
@@ -4703,7 +4710,7 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
-  solady@https://codeload.github.com/vectorized/solady/tar.gz/f74d6b6cec7e5f72f57949dfa5d51b632bcc29a6: {}
+  solady@https://codeload.github.com/vectorized/solady/tar.gz/f833eadd4591da7e8e455eab779bf1d918486847: {}
 
   solarray@https://codeload.github.com/sablier-labs/solarray/tar.gz/6bf10cb34cdace52a3ba5fe437e78cc82df92684: {}
 
@@ -4791,6 +4798,8 @@ snapshots:
       semver: 7.6.3
       shelljs: 0.8.5
       web3-utils: 1.10.4
+
+  solidity-stringutils@https://codeload.github.com/Arachnid/solidity-stringutils/tar.gz/4b2fcc43fa0426e19ce88b1f1ec16f5903a2e461: {}
 
   solmate@https://codeload.github.com/transmissions11/solmate/tar.gz/97bdb2003b70382996a79a406813f76417b1cf90: {}
 

--- a/remappings.txt
+++ b/remappings.txt
@@ -21,3 +21,4 @@ solarray/=node_modules/solarray/src/
 freshcryptolib/=node_modules/freshcryptolib/solidity/src/
 kernel/=node_modules/@zerodev/kernel/src/
 ExcessivelySafeCall/=node_modules/excessively-safe-call/src/
+stringutils/=node_modules/stringutils/src/

--- a/test/unit/SmartERC1271.t.sol
+++ b/test/unit/SmartERC1271.t.sol
@@ -125,6 +125,8 @@ contract SmartSessionERC1271Test is BaseTest {
         (t.fields, t.name, t.version, t.chainId, t.verifyingContract, t.salt, t.extensions) =
             EIP712(account).eip712Domain();
 
+        console2.log("name in test " , t.name);
+
         return abi.encode(
             t.fields,
             keccak256(bytes(t.name)),

--- a/test/unit/SmartERC1271.t.sol
+++ b/test/unit/SmartERC1271.t.sol
@@ -38,9 +38,9 @@ contract SmartSessionERC1271Test is BaseTest {
         instance.installModule({ moduleTypeId: MODULE_TYPE_FALLBACK, module: address(fallbackModule), data: _fallback });
 
         Session memory session = Session({
-            sessionValidator: ISessionValidator(address(yesSigner)),
+            sessionValidator: ISessionValidator(address(simpleSigner)),
             salt: keccak256("salt"),
-            sessionValidatorInitData: "mockInitData",
+            sessionValidatorInitData: abi.encodePacked(sessionSigner1.addr),
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("Permit(bytes32 stuff)", _getEmptyPolicyDatas(address(yesPolicy))),
             actions: new ActionData[](0)
@@ -124,8 +124,6 @@ contract SmartSessionERC1271Test is BaseTest {
         _AccountDomainStruct memory t;
         (t.fields, t.name, t.version, t.chainId, t.verifyingContract, t.salt, t.extensions) =
             EIP712(account).eip712Domain();
-
-        console2.log("name in test " , t.name);
 
         return abi.encode(
             t.fields,


### PR DESCRIPTION
- Fix fallback to use Account data instead of Module eip712 domain
- Fix test to use actual signer instead of YesSigner
- Fix Smart Session to use full account's eip712 domain, not (own domain + verifyingAddress=address(account))

**Motivation:**
As 1271 signature is per account, not per module, it is more consistent to use account's data for 712 domain separator of 1271 sig. 
If erc7579 Account implements EIP-712/EIP-5267 , fallback won't be triggered and account's 712 domain will be used.
If account doesn't , then we can take Account Id data from it and build 712 name and version out of it in a compatibilityFallback => return 712 domain

In future I suggest renaming SmartSessionCompatibilityFallback to ERC7739CompatibilityFallback and ship it in a separate template repo together with ERC7739 Validator Base contract.