### PR TITLE
Remove PermissionId from enable mode sig

### DIFF
--- a/contracts/SmartSession.sol
+++ b/contracts/SmartSession.sol
@@ -108,6 +108,8 @@ contract SmartSession is ISmartSession, SmartSessionBase, SmartSessionERC7739 {
         // after enabling the session, the policies will be enforced on the userOp similarly to the SmartSession.USE
         else if (mode.isEnableMode()) {
             
+            // unpack the EnableSession data and signature
+            // calculate the permissionId from the Session data
             EnableSession memory enableData;
             bytes memory usePermissionSig;
             (enableData, usePermissionSig) = packedSig.decodeEnable();
@@ -139,7 +141,6 @@ contract SmartSession is ISmartSession, SmartSessionBase, SmartSessionERC7739 {
      * @param mode The SmartSession mode being used
      */
     function _enablePolicies(
-        //bytes calldata packedSig,
         EnableSession memory enableData,
         PermissionId permissionId,
         address account,
@@ -148,9 +149,6 @@ contract SmartSession is ISmartSession, SmartSessionBase, SmartSessionERC7739 {
         internal
         
     {
-        // Decode the enable data from the packed signature
-       
-
         // Increment nonce to prevent replay attacks
         uint256 nonce = $signerNonce[permissionId][account]++;
         bytes32 hash = enableData.getAndVerifyDigest(account, nonce, mode);

--- a/contracts/lib/EncodeLib.sol
+++ b/contracts/lib/EncodeLib.sol
@@ -13,22 +13,6 @@ library EncodeLib {
 
     error ChainIdAndHashesLengthMismatch(uint256 chainIdsLength, uint256 hashesLength);
 
-    /* function packMode(
-        bytes memory data,
-        SmartSessionMode mode,
-        PermissionId permissionId
-    )
-        internal
-        pure
-        returns (bytes memory packed)
-    {
-        if (mode.isEnableMode()) {
-            packed = abi.encodePacked(mode, data);
-        } else {
-            packed = abi.encodePacked(mode, permissionId, data);
-        }
-    }
- */
     function unpackMode(
         bytes calldata packed
     )
@@ -48,7 +32,6 @@ library EncodeLib {
     function encodeUse(PermissionId permissionId, bytes memory sig) internal pure returns (bytes memory userOpSig) {
         bytes memory d = abi.encode(sig).flzCompress();
         userOpSig = abi.encodePacked(SmartSessionMode.USE, permissionId, d);
-        //d.packMode(SmartSessionMode.USE, permissionId);
     }
 
     function decodeUse(bytes memory packedSig) internal pure returns (bytes memory signature) {
@@ -56,7 +39,6 @@ library EncodeLib {
     }
 
     function encodeUnsafeEnable(
-        //PermissionId permissionId,
         bytes memory sig,
         EnableSession memory enableData
     )
@@ -67,7 +49,6 @@ library EncodeLib {
         bytes memory data = abi.encode(enableData, sig);
         data = data.flzCompress();
         packedSig = abi.encodePacked(SmartSessionMode.UNSAFE_ENABLE, data);
-        //data.packMode(SmartSessionMode.UNSAFE_ENABLE, bytes32(0));
     }
 
     function decodeEnable(

--- a/contracts/lib/EncodeLib.sol
+++ b/contracts/lib/EncodeLib.sol
@@ -30,8 +30,7 @@ library EncodeLib {
     }
 
     function encodeUse(PermissionId permissionId, bytes memory sig) internal pure returns (bytes memory userOpSig) {
-        bytes memory d = abi.encode(sig).flzCompress();
-        userOpSig = abi.encodePacked(SmartSessionMode.USE, permissionId, d);
+        userOpSig = abi.encodePacked(SmartSessionMode.USE, permissionId, abi.encode(sig).flzCompress());
     }
 
     function decodeUse(bytes memory packedSig) internal pure returns (bytes memory signature) {
@@ -46,9 +45,7 @@ library EncodeLib {
         pure
         returns (bytes memory packedSig)
     {
-        bytes memory data = abi.encode(enableData, sig);
-        data = data.flzCompress();
-        packedSig = abi.encodePacked(SmartSessionMode.UNSAFE_ENABLE, data);
+        packedSig = abi.encodePacked(SmartSessionMode.UNSAFE_ENABLE, abi.encode(enableData, sig).flzCompress());
     }
 
     function decodeEnable(

--- a/test/mock/erc7679/UserOpBuilder.sol
+++ b/test/mock/erc7679/UserOpBuilder.sol
@@ -116,7 +116,7 @@ contract UserOperationBuilder is IUserOperationBuilder {
             if (isEnabled) {
                 return EncodeLib.encodeUse(permissionId, userOperation.signature);
             } else {
-                return EncodeLib.encodeEnable(permissionId, userOperation.signature, enableData);
+                return EncodeLib.encodeUnsafeEnable(userOperation.signature, enableData);
             }
         } catch (bytes memory error) {
             revert InvalidPermission(error);

--- a/test/unit/SessionManagementTest.t.sol
+++ b/test/unit/SessionManagementTest.t.sol
@@ -56,7 +56,7 @@ contract SessionManagementTest is BaseTest {
             abi.encodePacked(mockK1, sign(ECDSA.toEthSignedMessageHash(hash), owner.key));
 
         // session key signs the userOP
-        userOpData.userOp.signature = EncodeLib.encodeEnable(permissionId, hex"4141414142", enableSessions);
+        userOpData.userOp.signature = EncodeLib.encodeUnsafeEnable(hex"4141414142", enableSessions);
 
         // execute userOp with modulekit
         userOpData.execUserOps();
@@ -154,7 +154,7 @@ contract SessionManagementTest is BaseTest {
         bytes32 hash = HashLib.multichainDigest(enableSessions.hashesAndChainIds);
         enableSessions.permissionEnableSig =
             abi.encodePacked(mockK1, sign(ECDSA.toEthSignedMessageHash(hash), owner.key));
-        userOpData.userOp.signature = EncodeLib.encodeEnable(permissionId, hex"4141414142", enableSessions);
+        userOpData.userOp.signature = EncodeLib.encodeUnsafeEnable(hex"4141414142", enableSessions);
 
         userOpData.execUserOps();
 
@@ -184,7 +184,7 @@ contract SessionManagementTest is BaseTest {
         userOpData.execUserOps();
 
         // lets try to replay the same session. THIS MUST FAIL, otherwise session keys can just reenable themselves
-        userOpData.userOp.signature = EncodeLib.encodeEnable(permissionId, hex"4141414142", enableSessions);
+        userOpData.userOp.signature = EncodeLib.encodeUnsafeEnable(hex"4141414142", enableSessions);
         instance.expect4337Revert();
         userOpData.execUserOps();
     }
@@ -250,7 +250,7 @@ contract SessionManagementTest is BaseTest {
         vm.prank(instance.account);
         smartSession.revokeEnableSignature(permissionId);
         // session key signs the userOP
-        userOpData.userOp.signature = EncodeLib.encodeEnable(permissionId, hex"4141414142", enableSessions);
+        userOpData.userOp.signature = EncodeLib.encodeUnsafeEnable(hex"4141414142", enableSessions);
 
         // execute userOp with modulekit
         instance.expect4337Revert();


### PR DESCRIPTION
Instead of passing unsigned `permissionId` to enable mode and then verify that it matches one, that is calculated out of signed data (session validator, sv initdata, salt) => just calculate it out of this data.
This saves 32 bytes of calldata for enable mode. 

Merges into #70 