### PR TITLE
Add Minimum Policies Configuration to Session

### DIFF
--- a/contracts/DataTypes.sol
+++ b/contracts/DataTypes.sol
@@ -59,6 +59,7 @@ struct Session {
     PolicyData[] userOpPolicies;
     ERC7739Data erc7739Policies;
     ActionData[] actions;
+    MinPoliciesConfig minPoliciesConfig;
 }
 
 struct MultiChainSession {
@@ -86,6 +87,11 @@ struct ActionData {
 struct ERC7739Data {
     string[] allowedERC7739Content;
     PolicyData[] erc1271Policies;
+}
+
+struct MinPoliciesConfig {
+    uint128 minUserOpPolicies;
+    uint128 minActionPolicies;
 }
 
 enum SmartSessionMode {

--- a/contracts/ISmartSession.sol
+++ b/contracts/ISmartSession.sol
@@ -46,6 +46,7 @@ interface ISmartSession {
     error UnsupportedExecutionType();
     error UnsupportedPolicy(address policy);
     error UnsupportedSmartSessionMode(SmartSessionMode mode);
+    error UnsafeMinPoliciesConfig();
 
     event NonceIterated(PermissionId permissionId, address account, uint256 newValue);
     event SessionValidatorEnabled(PermissionId permissionId, address sessionValidator, address smartAccount);

--- a/contracts/core/SmartSessionBase.sol
+++ b/contracts/core/SmartSessionBase.sol
@@ -36,6 +36,7 @@ abstract contract SmartSessionBase is ISmartSession, NonceManager {
     EnumerableSet.Bytes32Set internal $enabledSessions;
     mapping(PermissionId permissionId => EnumerableSet.Bytes32Set enabledContentHashes) internal $enabledERC7739Content;
     mapping(PermissionId permissionId => mapping(address smartAccount => SignerConf conf)) internal $sessionValidators;
+    mapping(PermissionId permissionId => mapping(address smartAccount => MinPoliciesConfig conf)) internal $minPoliciesConfigs;
 
     /**
      * @notice Enable user operation policies for a specific permission
@@ -224,6 +225,9 @@ abstract contract SmartSessionBase is ISmartSession, NonceManager {
                 smartAccount: msg.sender,
                 useRegistry: true
             });
+
+            // Set the minimum policy configuration for this session
+            $minPoliciesConfigs[permissionId][msg.sender] = session.minPoliciesConfig;
 
             permissionIds[i] = permissionId;
             emit SessionCreated(permissionId, msg.sender);

--- a/test/unit/EIP712Test.t.sol
+++ b/test/unit/EIP712Test.t.sol
@@ -29,18 +29,19 @@ contract EIP712Test is Test {
     function test_type_notation() public {
         // test multichain hash
         string memory expectedMultiChainSessionTypeHash =
-            "MultiChainSessionEIP712(ChainSessionEIP712[] sessionsAndChainIds)ActionData(bytes4 actionTargetSelector,address actionTarget,PolicyData[] actionPolicies)ChainSessionEIP712(uint64 chainId,SessionEIP712 session)ERC7739Data(string[] allowedERC7739Content,PolicyData[] erc1271Policies)PolicyData(address policy,bytes initData)SessionEIP712(address account,address smartSession,uint8 mode,address sessionValidator,bytes32 salt,bytes sessionValidatorInitData,PolicyData[] userOpPolicies,ERC7739Data erc7739Policies,ActionData[] actions,uint256 nonce)";
+            "MultiChainSessionEIP712(ChainSessionEIP712[] sessionsAndChainIds)ActionData(bytes4 actionTargetSelector,address actionTarget,PolicyData[] actionPolicies)ChainSessionEIP712(uint64 chainId,SessionEIP712 session)ERC7739Data(string[] allowedERC7739Content,PolicyData[] erc1271Policies)PolicyData(address policy,bytes initData)SessionEIP712(address account,address smartSession,uint8 mode,address sessionValidator,bytes32 salt,bytes sessionValidatorInitData,PolicyData[] userOpPolicies,ERC7739Data erc7739Policies,ActionData[] actions,uint128 minUserOpPolicies,uint128 minActionPolicies,uint256 nonce)";
         bytes32 hash = keccak256(abi.encodePacked(expectedMultiChainSessionTypeHash));
         assertEq(hash, MULTICHAIN_SESSION_TYPEHASH);
 
         string memory expectedChainSession =
-            "ChainSessionEIP712(uint64 chainId,SessionEIP712 session)ActionData(bytes4 actionTargetSelector,address actionTarget,PolicyData[] actionPolicies)ERC7739Data(string[] allowedERC7739Content,PolicyData[] erc1271Policies)PolicyData(address policy,bytes initData)SessionEIP712(address account,address smartSession,uint8 mode,address sessionValidator,bytes32 salt,bytes sessionValidatorInitData,PolicyData[] userOpPolicies,ERC7739Data erc7739Policies,ActionData[] actions,uint256 nonce)";
+            "ChainSessionEIP712(uint64 chainId,SessionEIP712 session)ActionData(bytes4 actionTargetSelector,address actionTarget,PolicyData[] actionPolicies)ERC7739Data(string[] allowedERC7739Content,PolicyData[] erc1271Policies)PolicyData(address policy,bytes initData)SessionEIP712(address account,address smartSession,uint8 mode,address sessionValidator,bytes32 salt,bytes sessionValidatorInitData,PolicyData[] userOpPolicies,ERC7739Data erc7739Policies,ActionData[] actions,uint128 minUserOpPolicies,uint128 minActionPolicies,uint256 nonce)";
         hash = keccak256(abi.encodePacked(expectedChainSession));
         assertEq(hash, CHAIN_SESSION_TYPEHASH);
 
         string memory expectedSession =
-            "SessionEIP712(address account,address smartSession,uint8 mode,address sessionValidator,bytes32 salt,bytes sessionValidatorInitData,PolicyData[] userOpPolicies,ERC7739Data erc7739Policies,ActionData[] actions,uint256 nonce)ActionData(bytes4 actionTargetSelector,address actionTarget,PolicyData[] actionPolicies)ERC7739Data(string[] allowedERC7739Content,PolicyData[] erc1271Policies)PolicyData(address policy,bytes initData)";
+            "SessionEIP712(address account,address smartSession,uint8 mode,address sessionValidator,bytes32 salt,bytes sessionValidatorInitData,PolicyData[] userOpPolicies,ERC7739Data erc7739Policies,ActionData[] actions,uint128 minUserOpPolicies,uint128 minActionPolicies,uint256 nonce)ActionData(bytes4 actionTargetSelector,address actionTarget,PolicyData[] actionPolicies)ERC7739Data(string[] allowedERC7739Content,PolicyData[] erc1271Policies)PolicyData(address policy,bytes initData)";
         hash = keccak256(abi.encodePacked(expectedSession));
+        console2.logBytes32(hash);
         assertEq(hash, SESSION_TYPEHASH);
     }
 
@@ -105,14 +106,15 @@ contract EIP712Test is Test {
             salt: bytes32(0x3200000000000000000000000000000000000000000000000000000000000000),
             userOpPolicies: new PolicyData[](0),
             erc7739Policies: ERC7739Data({ allowedERC7739Content: new string[](0), erc1271Policies: new PolicyData[](0) }),
-            actions: actions
+            actions: actions,
+            minPoliciesConfig: MinPoliciesConfig({ minUserOpPolicies: 0, minActionPolicies: 1 })
         });
 
-        bytes32 expected_typehash = 0x45f5f60cec99c2d0a0198ec513b02d6926b8ec63dfaf7e9afba954108dd97ebd;
+        bytes32 expected_typehash = 0x331eb8e0a76a7114445d344052baeee8ab2036048d7713c62f53274a07c1a767;
         assertEq(expected_typehash, SESSION_TYPEHASH);
 
         bytes32 hash = helper.hash(session);
-        bytes32 expected_hash = 0x34d50dad7b10ff2a2d69fdf4e07806ab4e6f444e8902b02c859c4e0ebdc63b3e;
+        bytes32 expected_hash = 0x90e1aee544e84e710e453e0e443052eb0e085df6e539efd6b5c599deaa08004f;
         assertEq(hash, expected_hash, "hash fn borked");
     }
 }

--- a/test/unit/ERC7715FlowTest.t.sol
+++ b/test/unit/ERC7715FlowTest.t.sol
@@ -37,7 +37,8 @@ contract ERC7715FlowTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("mockContent", _getEmptyPolicyDatas(address(yesPolicy))),
-            actions: _getEmptyActionDatas(_target, MockTarget.setValue.selector, address(yesPolicy))
+            actions: _getEmptyActionDatas(_target, MockTarget.setValue.selector, address(yesPolicy)),
+            minPoliciesConfig: MinPoliciesConfig({ minUserOpPolicies: 1, minActionPolicies: 1 })
         });
         // predict permissionId correlating to EnableSession
         permissionId = smartSession.getPermissionId(session);

--- a/test/unit/MultipleSessions.t.sol
+++ b/test/unit/MultipleSessions.t.sol
@@ -32,7 +32,8 @@ contract MultipleSessionsTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("mockContent", _getEmptyPolicyDatas(address(yesPolicy))),
-            actions: _getEmptyActionDatas(target, selector, address(yesPolicy))
+            actions: _getEmptyActionDatas(target, selector, address(yesPolicy)),
+            minPoliciesConfig: MinPoliciesConfig({ minUserOpPolicies: 1, minActionPolicies: 1 })
         });
 
         // predict permissionId correlating to EnableSession

--- a/test/unit/SessionManagementTest.t.sol
+++ b/test/unit/SessionManagementTest.t.sol
@@ -55,7 +55,8 @@ contract SessionManagementTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("mockContent", _getEmptyPolicyDatas(address(yesPolicy))),
-            actions: _getEmptyActionDatas(_target, MockTarget.setValue.selector, address(yesPolicy))
+            actions: _getEmptyActionDatas(_target, MockTarget.setValue.selector, address(yesPolicy)),
+            minPoliciesConfig: MinPoliciesConfig({ minUserOpPolicies: 1, minActionPolicies: 1 })
         });
 
         // predict permissionId correlating to EnableSession
@@ -112,7 +113,8 @@ contract SessionManagementTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("mockContent", _getEmptyPolicyDatas(address(yesPolicy))),
-            actions: _getEmptyActionDatas(_target, MockTarget.setValue.selector, address(yesPolicy))
+            actions: _getEmptyActionDatas(_target, MockTarget.setValue.selector, address(yesPolicy)),
+            minPoliciesConfig: MinPoliciesConfig({ minUserOpPolicies: 1, minActionPolicies: 1 })
         });
 
         permissionId = smartSession.getPermissionId(session);
@@ -166,7 +168,8 @@ contract SessionManagementTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: userOpPolicyData,
             erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
-            actions: _getEmptyActionDatas(address(target), MockTarget.setValue.selector, address(yesPolicy2)) 
+            actions: _getEmptyActionDatas(address(target), MockTarget.setValue.selector, address(yesPolicy2)),
+            minPoliciesConfig: MinPoliciesConfig({ minUserOpPolicies: 1, minActionPolicies: 1 })
         });
 
         enableSessions = _makeMultiChainEnableData(permissionId, session, instance, SmartSessionMode.UNSAFE_ENABLE);
@@ -248,7 +251,8 @@ contract SessionManagementTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("mockContent", _getEmptyPolicyDatas(address(yesPolicy))),
-            actions: _getEmptyActionDatas(_target, MockTarget.setValue.selector, address(yesPolicy))
+            actions: _getEmptyActionDatas(_target, MockTarget.setValue.selector, address(yesPolicy)),
+            minPoliciesConfig: MinPoliciesConfig({ minUserOpPolicies: 1, minActionPolicies: 1 })
         });
 
         // predict permissionId correlating to EnableSession
@@ -292,7 +296,8 @@ contract SessionManagementTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: new PolicyData[](0),
             erc7739Policies: _getEmptyERC7739Data("mockContent", _getEmptyPolicyDatas(address(yesPolicy))),
-            actions: actionData
+            actions: actionData,
+            minPoliciesConfig: MinPoliciesConfig({ minUserOpPolicies: 0, minActionPolicies: 1 })
         });
 
         PermissionId multiActionPermissionId = smartSession.getPermissionId(session);

--- a/test/unit/SmartERC1271.t.sol
+++ b/test/unit/SmartERC1271.t.sol
@@ -43,7 +43,8 @@ contract SmartSessionERC1271Test is BaseTest {
             sessionValidatorInitData: abi.encodePacked(sessionSigner1.addr),
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("Permit(bytes32 stuff)", _getEmptyPolicyDatas(address(yesPolicy))),
-            actions: new ActionData[](0)
+            actions: new ActionData[](0),
+            minPoliciesConfig: MinPoliciesConfig({ minUserOpPolicies: 1, minActionPolicies: 1 })
         });
 
         Session[] memory sessions = new Session[](1);

--- a/test/unit/SpendingLimit.t.sol
+++ b/test/unit/SpendingLimit.t.sol
@@ -53,7 +53,8 @@ contract SpendingLimitTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("mockContent", _getEmptyPolicyDatas(address(yesPolicy))),
-            actions: actionDatas
+            actions: actionDatas,
+            minPoliciesConfig: MinPoliciesConfig({ minUserOpPolicies: 1, minActionPolicies: 1 })
         });
 
         permissionId = smartSession.getPermissionId(session);

--- a/test/unit/UniActionPolicy.t.sol
+++ b/test/unit/UniActionPolicy.t.sol
@@ -109,7 +109,8 @@ contract UniversalActionPolicyTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: new PolicyData[](0),
             erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
-            actions: actionDatas
+            actions: actionDatas,
+            minPoliciesConfig: MinPoliciesConfig({ minUserOpPolicies: 0, minActionPolicies: 1 })
         });
 
         permissionId = smartSession.getPermissionId(session);

--- a/test/utils/Multichain712Digest.t.sol
+++ b/test/utils/Multichain712Digest.t.sol
@@ -21,7 +21,8 @@ contract Multichain712DigestTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("mockContent", _getEmptyPolicyDatas(address(yesPolicy))),
-            actions: _getEmptyActionDatas(makeAddr("target"), bytes4(0x41414141), address(yesPolicy))
+            actions: _getEmptyActionDatas(makeAddr("target"), bytes4(0x41414141), address(yesPolicy)),
+            minPoliciesConfig: MinPoliciesConfig({ minUserOpPolicies: 1, minActionPolicies: 1 })
         });
 
         // Make sessionsAndChainIds


### PR DESCRIPTION
- Adds 
```
struct MinPoliciesConfig {
    uint128 minUserOpPolicies;
    uint128 minActionPolicies;
}
```
to the session struct. 

Templates would be:

**Open Permission:**
Can execute any actions. 
Configuring actionId means just configuring additional restrictions to a given action (but it makes very little sense)
```
{
    minUserOpPolicies > 0,
    minActionPolicies = 0
}
```

**Strict Permission:**
Only executes configured actions. Configuring an action means basically allowing session key to execute it.
```
{
    minUserOpPolicies >= 0,
    minActionPolicies > 0
}
```
