### PR TITLE
Fixing the Associated Array Lib storage layout

### DIFF
--- a/contracts/utils/AssociatedArrayLib.sol
+++ b/contracts/utils/AssociatedArrayLib.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/console2.sol";
-
 /**
   ERC-4337 / ERC-7562 Compatible array lib.
   This array can be used as mapping value in mappings such as (address account => Bytes32Array array) 
@@ -96,11 +94,6 @@ library AssociatedArrayLib {
 
     function _push(Array storage s, address account, bytes32 value) private {
         bytes32 slot = _slot(s, account);
-        uint256  _index;
-        assembly {
-          _index := sload(slot)
-        }
-        console2.log("index in lib ", _index);
         assembly {
             // load length (stored @ slot) => this would be the index of a new element
             let index := sload(slot)

--- a/contracts/utils/AssociatedArrayLib.sol
+++ b/contracts/utils/AssociatedArrayLib.sol
@@ -1,6 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "forge-std/console2.sol";
+
+/**
+  ERC-4337 / ERC-7562 Compatible array lib.
+  This array can be used as mapping value in mappings such as (address account => Bytes32Array array) 
+  Array size should not exceed 128.
+*/
+
 library AssociatedArrayLib {
     using AssociatedArrayLib for *;
 
@@ -37,7 +45,7 @@ library AssociatedArrayLib {
                 mstore(0x20, index)
                 revert(0x1c, 0x24)
             }
-            value := sload(add(slot, mul(0x20, add(index, 1))))
+            value := sload(add(slot, add(index, 1)))
         }
     }
 
@@ -82,18 +90,27 @@ library AssociatedArrayLib {
                 mstore(0x20, index)
                 revert(0x1c, 0x24)
             }
-            sstore(add(slot, mul(0x20, add(index, 1))), value)
+            sstore(add(slot, add(index, 1)), value)
         }
     }
 
     function _push(Array storage s, address account, bytes32 value) private {
         bytes32 slot = _slot(s, account);
+        uint256  _index;
         assembly {
-            // load length (stored @ slot), add 1 to it => index.
-            // mul index by 0x20 and add it to orig slot to get the next free slot
-            let index := add(sload(slot), 1)
-            sstore(add(slot, mul(0x20, index)), value)
-            sstore(slot, index) //increment length by 1
+          _index := sload(slot)
+        }
+        console2.log("index in lib ", _index);
+        assembly {
+            // load length (stored @ slot) => this would be the index of a new element
+            let index := sload(slot)
+            if gt(index, 127) {
+                mstore(0, 0x8277484f) // `AssociatedArray_OutOfBounds(uint256)`
+                mstore(0x20, index)
+                revert(0x1c, 0x24)
+            }
+            sstore(add(slot, add(index, 1)), value) // store at (slot+index+1) => 0th element is stored at slot+1
+            sstore(slot, add(index, 1)) // increment length by 1
         }
     }
 
@@ -128,7 +145,7 @@ library AssociatedArrayLib {
             // this is the 'unchecked' version of _set(slot, __length - 1, 0)
             // as we use length-1 as index, so the check is excessive.
             // also removes extra -1 and +1 operations
-            sstore(add(slot, mul(0x20, __length)), 0)
+            sstore(add(slot, __length), 0)
             // store new length
             sstore(slot, sub(__length, 1))
         }

--- a/test/utils/EnumerableSet.t.sol
+++ b/test/utils/EnumerableSet.t.sol
@@ -124,9 +124,15 @@ contract EnumerableSetTest is Test {
         assertTrue(values[0] == value2 || values[1] == value2);
     }
 
-    function testFuzzBytes32Set(bytes32[] memory testValues) public {
+    function testFuzzBytes32Set(bytes32[] memory _testValues) public {
+        uint256 length = bound(_testValues.length, 0, 128);
+        bytes32[] memory testValues = new bytes32[](length);
+        for (uint256 j; j < length; j++) {
+            testValues[j] = _testValues[j];
+        }
+
         uint256 uniqueCount = 0;
-        for (uint256 i = 0; i < testValues.length; i++) {
+        for (uint256 i = 0; i < length; i++) {
             if (bytes32Set.add(ACCOUNT, testValues[i])) {
                 uniqueCount++;
             }
@@ -148,7 +154,13 @@ contract EnumerableSetTest is Test {
         assertEq(bytes32Set.length(ACCOUNT), 0);
     }
 
-    function testFuzzAddressSet(address[] memory testValues) public {
+    function testFuzzAddressSet(address[] memory _testValues) public {
+        uint256 length = bound(_testValues.length, 0, 128);
+        address[] memory testValues = new address[](length);
+        for (uint256 j; j < length; j++) {
+            testValues[j] = _testValues[j];
+        }
+        
         uint256 uniqueCount = 0;
         for (uint256 i = 0; i < testValues.length; i++) {
             if (addressSet.add(ACCOUNT, testValues[i])) {
@@ -172,7 +184,13 @@ contract EnumerableSetTest is Test {
         assertEq(addressSet.length(ACCOUNT), 0);
     }
 
-    function testFuzzUintSet(uint256[] memory testValues) public {
+    function testFuzzUintSet(uint256[] memory _testValues) public {
+        uint256 length = bound(_testValues.length, 0, 128);
+        uint256[] memory testValues = new uint256[](length);
+        for (uint256 j; j < length; j++) {
+            testValues[j] = _testValues[j];
+        }
+
         uint256 uniqueCount = 0;
         for (uint256 i = 0; i < testValues.length; i++) {
             if (uintSet.add(ACCOUNT, testValues[i])) {


### PR DESCRIPTION
Fix [this](https://github.com/Renascence-Labs/2024-10-smartsession/issues/24).

- Fix functions
- Add check no more than 128 policies
- Fix tests