### PR TITLE
adding feature to inspect userOp.paymasterAndData

### DIFF
--- a/contracts/DataTypes.sol
+++ b/contracts/DataTypes.sol
@@ -60,6 +60,7 @@ struct Session {
     PolicyData[] userOpPolicies;
     ERC7739Data erc7739Policies;
     ActionData[] actions;
+    bool canUsePaymaster;
 }
 
 struct MultiChainSession {

--- a/contracts/ISmartSession.sol
+++ b/contracts/ISmartSession.sol
@@ -59,6 +59,8 @@ interface ISmartSession {
     event SessionCreated(PermissionId permissionId, address account);
     event SessionRemoved(PermissionId permissionId, address smartAccount);
 
+    event PermissionIdCanUsePaymaster(PermissionId permissionId, address smartAccount, bool enabled);
+
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                           ERC7579                          */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/

--- a/contracts/ISmartSession.sol
+++ b/contracts/ISmartSession.sol
@@ -49,6 +49,7 @@ interface ISmartSession {
     error UnsupportedPolicy(address policy);
     error UnsupportedSmartSessionMode(SmartSessionMode mode);
     error ForbiddenValidationData();
+    error PaymasterValidationNotEnabled(PermissionId permissionId);
 
     event NonceIterated(PermissionId permissionId, address account, uint256 newValue);
     event SessionValidatorEnabled(PermissionId permissionId, address sessionValidator, address smartAccount);

--- a/contracts/SmartSession.sol
+++ b/contracts/SmartSession.sol
@@ -32,6 +32,8 @@ import { ValidationDataLib } from "./lib/ValidationDataLib.sol";
 import { IdLib } from "./lib/IdLib.sol";
 import { SmartSessionModeLib } from "./lib/SmartSessionModeLib.sol";
 
+import "forge-std/console2.sol";
+
 /**
  * @title SmartSession
  * @author [alphabetically] Filipp Makarov (Biconomy) & zeroknots.eth (Rhinestone)
@@ -257,8 +259,9 @@ contract SmartSession is ISmartSession, SmartSessionBase, SmartSessionERC7739 {
             // any
             // paymasters. Should this be the case, a UserOpPolicy must run, this could be a yes policy, or a specific
             // UserOpPolicy that can destructure the paymasterAndData and inspect it
-            if (userOp.paymasterAndData.length != 0 && $canUsePaymaster[permissionId][account]) {
-                minPolicies = 1;
+            if (userOp.paymasterAndData.length != 0) {
+                if ($canUsePaymaster[permissionId][account]) minPolicies = 1;
+                else revert PaymasterValidationNotEnabled(permissionId);
             }
             /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
             /*                    Check UserOp Policies                   */

--- a/test/mock/MockPaymaster.sol
+++ b/test/mock/MockPaymaster.sol
@@ -1,0 +1,21 @@
+import "@ERC4337/account-abstraction/contracts/core/BasePaymaster.sol";
+import "@ERC4337/account-abstraction/contracts/core/Helpers.sol";
+import "@ERC4337/account-abstraction/contracts/interfaces/IEntryPoint.sol";
+
+contract MockPaymaster is BasePaymaster {
+    constructor(IEntryPoint _entryPoint) BasePaymaster(_entryPoint) { }
+
+    function _validatePaymasterUserOp(
+        PackedUserOperation calldata userOp,
+        bytes32 userOpHash,
+        uint256 maxCost
+    )
+        internal
+        virtual
+        override
+        returns (bytes memory context, uint256 validationData)
+    {
+        context = "";
+        validationData = _packValidationData(false, uint48(type(uint48).max), uint48(0));
+    }
+}

--- a/test/unit/EIP712Test.t.sol
+++ b/test/unit/EIP712Test.t.sol
@@ -130,7 +130,8 @@ contract EIP712Test is Test {
             salt: bytes32(0),
             userOpPolicies: policyDatas,
             erc7739Policies: _getEmptyERC7739Data("mockContent", _getEmptyPolicyDatas(address(0))),
-            actions: actions
+            actions: actions,
+            canUsePaymaster: true
         });
 
         assertEq(

--- a/test/unit/ERC7715FlowTest.t.sol
+++ b/test/unit/ERC7715FlowTest.t.sol
@@ -35,7 +35,8 @@ contract ERC7715FlowTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
-            actions: _getEmptyActionDatas(_target, MockTarget.setValue.selector, address(yesPolicy))
+            actions: _getEmptyActionDatas(_target, MockTarget.setValue.selector, address(yesPolicy)),
+            canUsePaymaster: true
         });
         // predict permissionId correlating to EnableSession
         permissionId = smartSession.getPermissionId(session);

--- a/test/unit/MultipleSessions.t.sol
+++ b/test/unit/MultipleSessions.t.sol
@@ -32,7 +32,8 @@ contract MultipleSessionsTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
-            actions: _getEmptyActionDatas(target, selector, address(yesPolicy))
+            actions: _getEmptyActionDatas(target, selector, address(yesPolicy)),
+            canUsePaymaster: true
         });
 
         // predict permissionId correlating to EnableSession

--- a/test/unit/OnInstall.t.sol
+++ b/test/unit/OnInstall.t.sol
@@ -31,7 +31,8 @@ contract OnInstallTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("mockContent", _getEmptyPolicyDatas(address(yesPolicy))),
-            actions: _getEmptyActionDatas(makeAddr("target"), bytes4(0x41414141), address(yesPolicy))
+            actions: _getEmptyActionDatas(makeAddr("target"), bytes4(0x41414141), address(yesPolicy)),
+            canUsePaymaster: true
         });
         Session[] memory sessions = new Session[](1);
         sessions[0] = session;

--- a/test/unit/PaymasterOptin.t.sol
+++ b/test/unit/PaymasterOptin.t.sol
@@ -1,0 +1,139 @@
+import "../Base.t.sol";
+import "contracts/core/SmartSessionBase.sol";
+import "solady/utils/ECDSA.sol";
+import "contracts/lib/IdLib.sol";
+
+import "contracts/external/policies/ERC20SpendingLimitPolicy.sol";
+import "solmate/test/utils/mocks/MockERC20.sol";
+import "forge-std/interfaces/IERC20.sol";
+import { MockPaymaster } from "../mock/MockPaymaster.sol";
+
+address constant ENTRYPOINT_ADDR = 0x0000000071727De22E5E9d8BAf0edAc6f37da032;
+
+contract PaymasterOptTest is BaseTest {
+    using IdLib for *;
+    using ModuleKitHelpers for *;
+    using ModuleKitUserOp for *;
+    using EncodeLib for PermissionId;
+
+    MockPaymaster paymaster;
+
+    MockERC20 token;
+    PermissionId permissionId;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        paymaster = new MockPaymaster(IEntryPoint(ENTRYPOINT_ADDR));
+        token = new MockERC20("MockToken", "MTK", 18);
+
+        paymaster.deposit{ value: 100 ether }();
+
+        token.mint(instance.account, 100 ether);
+    }
+
+    function test_transferWithPaymaster() public {
+        Session memory session = Session({
+            sessionValidator: ISessionValidator(address(yesSessionValidator)),
+            salt: keccak256("salt"),
+            sessionValidatorInitData: "mockInitData",
+            userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
+            erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
+            actions: _getEmptyActionDatas(address(token), IERC20.transfer.selector, address(yesPolicy)),
+            canUsePaymaster: true
+        });
+
+        permissionId = smartSession.getPermissionId(session);
+
+        Session[] memory enableSessionsArray = new Session[](1);
+        enableSessionsArray[0] = session;
+
+        vm.prank(instance.account);
+        smartSession.enableSessions(enableSessionsArray);
+
+        address recipient = makeAddr("recipient");
+
+        UserOpData memory userOpData = instance.getExecOps({
+            target: address(token),
+            value: 0,
+            callData: abi.encodeCall(IERC20.transfer, (recipient, 1 ether)),
+            txValidator: address(smartSession)
+        });
+        // session key signs the userOP NOTE: this is using encodeUse() since the session is already enabled
+        userOpData.userOp.signature = EncodeLib.encodeUse({ permissionId: permissionId, sig: hex"4141414141" });
+        userOpData.userOp.paymasterAndData =
+            abi.encodePacked(address(paymaster), uint128(1_000_000), uint128(10_000_000));
+        userOpData.execUserOps();
+        assertEq(token.balanceOf(recipient), 1 ether);
+    }
+
+    function test_transferWithPaymaster_paymasterNotEnabled() public {
+        Session memory session = Session({
+            sessionValidator: ISessionValidator(address(yesSessionValidator)),
+            salt: keccak256("salt"),
+            sessionValidatorInitData: "mockInitData",
+            userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
+            erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
+            actions: _getEmptyActionDatas(address(token), IERC20.transfer.selector, address(yesPolicy)),
+            canUsePaymaster: false // cant use paymaster
+         });
+
+        permissionId = smartSession.getPermissionId(session);
+
+        Session[] memory enableSessionsArray = new Session[](1);
+        enableSessionsArray[0] = session;
+
+        vm.prank(instance.account);
+        smartSession.enableSessions(enableSessionsArray);
+
+        address recipient = makeAddr("recipient");
+
+        UserOpData memory userOpData = instance.getExecOps({
+            target: address(token),
+            value: 0,
+            callData: abi.encodeCall(IERC20.transfer, (recipient, 1 ether)),
+            txValidator: address(smartSession)
+        });
+        // session key signs the userOP NOTE: this is using encodeUse() since the session is already enabled
+        userOpData.userOp.signature = EncodeLib.encodeUse({ permissionId: permissionId, sig: hex"4141414141" });
+        userOpData.userOp.paymasterAndData =
+            abi.encodePacked(address(paymaster), uint128(1_000_000), uint128(10_000_000));
+        instance.expect4337Revert();
+        userOpData.execUserOps();
+    }
+
+    function test_transferWithPaymaster_paymasterEnabledNoPolicy() public {
+        Session memory session = Session({
+            sessionValidator: ISessionValidator(address(yesSessionValidator)),
+            salt: keccak256("salt"),
+            sessionValidatorInitData: "mockInitData",
+            userOpPolicies: new PolicyData[](0),
+            erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
+            actions: _getEmptyActionDatas(address(token), IERC20.transfer.selector, address(yesPolicy)),
+            canUsePaymaster: true
+        });
+
+        permissionId = smartSession.getPermissionId(session);
+
+        Session[] memory enableSessionsArray = new Session[](1);
+        enableSessionsArray[0] = session;
+
+        vm.prank(instance.account);
+        smartSession.enableSessions(enableSessionsArray);
+
+        address recipient = makeAddr("recipient");
+
+        UserOpData memory userOpData = instance.getExecOps({
+            target: address(token),
+            value: 0,
+            callData: abi.encodeCall(IERC20.transfer, (recipient, 1 ether)),
+            txValidator: address(smartSession)
+        });
+        // session key signs the userOP NOTE: this is using encodeUse() since the session is already enabled
+        userOpData.userOp.signature = EncodeLib.encodeUse({ permissionId: permissionId, sig: hex"4141414141" });
+        userOpData.userOp.paymasterAndData =
+            abi.encodePacked(address(paymaster), uint128(1_000_000), uint128(10_000_000));
+        instance.expect4337Revert();
+        userOpData.execUserOps();
+    }
+}

--- a/test/unit/SessionManagementTest.t.sol
+++ b/test/unit/SessionManagementTest.t.sol
@@ -53,7 +53,8 @@ contract SessionManagementTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
-            actions: _getEmptyActionDatas(_target, MockTarget.setValue.selector, address(yesPolicy))
+            actions: _getEmptyActionDatas(_target, MockTarget.setValue.selector, address(yesPolicy)),
+            canUsePaymaster: true
         });
 
         // predict permissionId correlating to EnableSession
@@ -110,7 +111,8 @@ contract SessionManagementTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
-            actions: _getEmptyActionDatas(_target, MockTarget.setValue.selector, address(yesPolicy))
+            actions: _getEmptyActionDatas(_target, MockTarget.setValue.selector, address(yesPolicy)),
+            canUsePaymaster: true
         });
 
         permissionId = smartSession.getPermissionId(session);
@@ -163,7 +165,8 @@ contract SessionManagementTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: userOpPolicyData,
             erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
-            actions: _getEmptyActionDatas(address(target), MockTarget.setValue.selector, address(yesPolicy2))
+            actions: _getEmptyActionDatas(address(target), MockTarget.setValue.selector, address(yesPolicy2)),
+            canUsePaymaster: true
         });
 
         enableSessions = _makeMultiChainEnableData(permissionId, session, instance, SmartSessionMode.UNSAFE_ENABLE);
@@ -223,7 +226,8 @@ contract SessionManagementTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
-            actions: _getEmptyActionDatas(_target, MockTarget.setValue.selector, address(yesPolicy))
+            actions: _getEmptyActionDatas(_target, MockTarget.setValue.selector, address(yesPolicy)),
+            canUsePaymaster: true
         });
 
         // predict permissionId correlating to EnableSession
@@ -267,7 +271,8 @@ contract SessionManagementTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: new PolicyData[](0),
             erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
-            actions: actionData
+            actions: actionData,
+            canUsePaymaster: true
         });
 
         PermissionId multiActionPermissionId = smartSession.getPermissionId(session);

--- a/test/unit/SmartERC1271.t.sol
+++ b/test/unit/SmartERC1271.t.sol
@@ -59,7 +59,8 @@ contract SmartSessionERC1271Test is BaseTest {
             sessionValidatorInitData: abi.encodePacked(sessionSigner1.addr),
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("Permit(bytes32 stuff)Permit", _getEmptyPolicyDatas(address(yesPolicy))),
-            actions: new ActionData[](0)
+            actions: new ActionData[](0),
+            canUsePaymaster: true
         });
 
         Session memory session_invalid = Session({
@@ -68,7 +69,8 @@ contract SmartSessionERC1271Test is BaseTest {
             sessionValidatorInitData: abi.encodePacked(sessionSigner1.addr),
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("Permit(bytes32 stuff)", new PolicyData[](0)),
-            actions: new ActionData[](0)
+            actions: new ActionData[](0),
+            canUsePaymaster: true
         });
 
         Session[] memory sessions = new Session[](2);

--- a/test/unit/SpendingLimit.t.sol
+++ b/test/unit/SpendingLimit.t.sol
@@ -53,7 +53,8 @@ contract SpendingLimitTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
-            actions: actionDatas
+            actions: actionDatas,
+            canUsePaymaster: true
         });
 
         permissionId = smartSession.getPermissionId(session);

--- a/test/unit/SudoAndStrictPermission.t.sol
+++ b/test/unit/SudoAndStrictPermission.t.sol
@@ -48,7 +48,8 @@ contract SudoAndStrictPermissionTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: new PolicyData[](0),
             erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
-            actions: actionDatas
+            actions: actionDatas,
+            canUsePaymaster: true
         });
 
         permissionId_sudo = smartSession.getPermissionId(session);
@@ -67,7 +68,8 @@ contract SudoAndStrictPermissionTest is BaseTest {
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
             //actions: actionDatas
-            actions: new ActionData[](0)
+            actions: new ActionData[](0),
+            canUsePaymaster: true
         });
 
         permissionId_strict = smartSession.getPermissionId(session);
@@ -91,7 +93,8 @@ contract SudoAndStrictPermissionTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
-            actions: actionDatas
+            actions: actionDatas,
+            canUsePaymaster: true
         });
 
         permissionId_strict2 = smartSession.getPermissionId(session);

--- a/test/unit/UniActionPolicy.t.sol
+++ b/test/unit/UniActionPolicy.t.sol
@@ -119,7 +119,8 @@ contract UniversalActionPolicyTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: new PolicyData[](0),
             erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
-            actions: actionDatas
+            actions: actionDatas,
+            canUsePaymaster: true
         });
 
         permissionId = smartSession.getPermissionId(session);

--- a/test/utils/Multichain712Digest.t.sol
+++ b/test/utils/Multichain712Digest.t.sol
@@ -21,7 +21,8 @@ contract Multichain712DigestTest is BaseTest {
             sessionValidatorInitData: "mockInitData",
             userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
             erc7739Policies: _getEmptyERC7739Data("0", new PolicyData[](0)),
-            actions: _getEmptyActionDatas(makeAddr("target"), bytes4(0x41414141), address(yesPolicy))
+            actions: _getEmptyActionDatas(makeAddr("target"), bytes4(0x41414141), address(yesPolicy)),
+            canUsePaymaster: true
         });
 
         // Make sessionsAndChainIds


### PR DESCRIPTION
To create more explicit UX, and force the user to opt-in that session
keys can use paymaster funds, I added an additional config sstore
mapping as well as the logic, that smartsession inspects
userop.paymasterAndData. if this field is not zero, at least one userOp
must run. this may be a yesPolicy to get the same behavior as before
this PR, but it can be a paymaster policy that inspects the
paymasterAndData for conditions

TODO: write tests for this case