### PR TITLE
Do not flz compress use mode sig = saves 28 bytes of calldata

### DIFF
--- a/contracts/SmartSession.sol
+++ b/contracts/SmartSession.sol
@@ -93,7 +93,7 @@ contract SmartSession is ISmartSession, SmartSessionBase, SmartSessionERC7739 {
                 permissionId: permissionId,
                 userOpHash: userOpHash,
                 userOp: userOp,
-                decompressedSignature: packedSig.decodeUse(),
+                decompressedSignature: packedSig,
                 account: account
             });
         }

--- a/contracts/lib/EncodeLib.sol
+++ b/contracts/lib/EncodeLib.sol
@@ -28,11 +28,7 @@ library EncodeLib {
     }
 
     function encodeUse(PermissionId permissionId, bytes memory sig) internal pure returns (bytes memory userOpSig) {
-        userOpSig = abi.encodePacked(SmartSessionMode.USE, permissionId, abi.encode(sig).flzCompress());
-    }
-
-    function decodeUse(bytes memory packedSig) internal pure returns (bytes memory signature) {
-        (signature) = abi.decode(packedSig.flzDecompress(), (bytes));
+        userOpSig = abi.encodePacked(SmartSessionMode.USE, permissionId, sig);
     }
 
     function encodeUnsafeEnable(


### PR DESCRIPTION
Stumbled upon the fact that flz.compressing pure secp256k1 65bytes sig (which is the case for the USE mode) makes it longer, increasing calldata 

this PR fixes it, saving 28 bytes of calldata for every usage and also some execution gas on encoding/decoding use mode sig.