### PR TITLE
Fix hardcoded useRegistry value for enabling sessionValidators

### DIFF
--- a/contracts/core/SmartSessionBase.sol
+++ b/contracts/core/SmartSessionBase.sol
@@ -329,7 +329,7 @@ abstract contract SmartSessionBase is ISmartSession, NonceManager {
                     smartAccount: msg.sender,
                     sessionValidator: session.sessionValidator,
                     sessionValidatorConfig: session.sessionValidatorInitData,
-                    useRegistry: true
+                    useRegistry: useRegistry
                 });
             }
             permissionIds[i] = permissionId;


### PR DESCRIPTION
Not sure if there is a rationale behind hardcoding this to true, but its inconsistent with the current inline docs:
```
@param useRegistry A flag to indicate whether to use a registry check for the policies and session validator
```
Hardcoding this to `true` also makes it incompatible with Kernel v3.1 because there's no way to setup trusted attesters prior to installing a module during initialisation.