### PR TITLE
Make SudoPolicy compatible with IUserOpPolicy

### DIFF
--- a/contracts/external/policies/SudoPolicy.sol
+++ b/contracts/external/policies/SudoPolicy.sol
@@ -4,13 +4,19 @@ pragma solidity ^0.8.23;
 
 import "../../DataTypes.sol";
 import {
-    IActionPolicy, I1271Policy, IPolicy, VALIDATION_SUCCESS, VALIDATION_FAILED
+    IUserOpPolicy,
+    IActionPolicy,
+    I1271Policy,
+    IPolicy,
+    VALIDATION_SUCCESS,
+    VALIDATION_FAILED
 } from "../../interfaces/IPolicy.sol";
 import { IERC165 } from "forge-std/interfaces/IERC165.sol";
 import { SubModuleLib } from "../../lib/SubModuleLib.sol";
 import { EnumerableSet } from "../../utils/EnumerableSet4337.sol";
+import { PackedUserOperation } from "modulekit/external/ERC4337.sol";
 
-contract SudoPolicy is IActionPolicy, I1271Policy {
+contract SudoPolicy is IUserOpPolicy, IActionPolicy, I1271Policy {
     using EnumerableSet for EnumerableSet.Bytes32Set;
 
     event SudoPolicyInstalledMultiplexer(address indexed account, address indexed multiplexer, ConfigId indexed id);
@@ -31,6 +37,17 @@ contract SudoPolicy is IActionPolicy, I1271Policy {
     function initializeWithMultiplexer(address account, ConfigId configId, bytes calldata /*initData*/ ) external {
         $enabledConfigs[msg.sender].add(account, ConfigId.unwrap(configId));
         emit IPolicy.PolicySet(configId, msg.sender, account);
+    }
+
+    function checkUserOpPolicy(
+        ConfigId, /*id*/
+        PackedUserOperation calldata /*userOp*/
+    )
+        external
+        pure
+        returns (uint256)
+    {
+        return VALIDATION_SUCCESS;
     }
 
     function checkAction(
@@ -63,7 +80,8 @@ contract SudoPolicy is IActionPolicy, I1271Policy {
     }
 
     function supportsInterface(bytes4 interfaceID) external pure override returns (bool) {
-        return interfaceID == type(IActionPolicy).interfaceId || interfaceID == type(I1271Policy).interfaceId
-            || interfaceID == type(IERC165).interfaceId || interfaceID == type(IPolicy).interfaceId;
+        return interfaceID == type(IUserOpPolicy).interfaceId || interfaceID == type(IActionPolicy).interfaceId
+            || interfaceID == type(I1271Policy).interfaceId || interfaceID == type(IERC165).interfaceId
+            || interfaceID == type(IPolicy).interfaceId;
     }
 }


### PR DESCRIPTION
This PR allows SudoPolicy to be assigned as an `IUserOpPolicy`. Without this we cannot assign a sudo session where `canUsePaymaster` is set to true since it would violate the following logic:

https://github.com/erc7579/smartsessions/blob/d7e85c38c25b4b6a07c60f309fa239bcb7e93dbd/contracts/SmartSession.sol#L244-L256

Without this fix we would need to create a seperate "SudoUserOpPolicy" if we want to ensure that the sudo session can be used with a paymaster.