### PR TITLE
Remove unused storage from the SudoPolicy

### DIFF
--- a/contracts/external/policies/SudoPolicy.sol
+++ b/contracts/external/policies/SudoPolicy.sol
@@ -17,17 +17,8 @@ import { EnumerableSet } from "../../utils/EnumerableSet4337.sol";
 import { PackedUserOperation } from "modulekit/external/ERC4337.sol";
 
 contract SudoPolicy is IUserOpPolicy, IActionPolicy, I1271Policy {
-    using EnumerableSet for EnumerableSet.Bytes32Set;
-
-    event SudoPolicyInstalledMultiplexer(address indexed account, address indexed multiplexer, ConfigId indexed id);
-    event SudoPolicyUninstalledAllAccount(address indexed account);
-    event SudoPolicySet(address indexed account, address indexed multiplexer, ConfigId indexed id);
-    event SudoPolicyRemoved(address indexed account, address indexed multiplexer, ConfigId indexed id);
-
-    mapping(address account => bool isInitialized) internal $initialized;
-    mapping(address multiplexer => EnumerableSet.Bytes32Set configIds) internal $enabledConfigs;
-
-    /**
+    
+        /**
      * Initializes the policy to be used by given account through multiplexer (msg.sender) such as Smart Sessions.
      * Overwrites state.
      * @notice ATTENTION: This method is called during permission installation as part of the enabling policies flow.
@@ -35,7 +26,6 @@ contract SudoPolicy is IUserOpPolicy, IActionPolicy, I1271Policy {
      * external contracts.
      */
     function initializeWithMultiplexer(address account, ConfigId configId, bytes calldata /*initData*/ ) external {
-        $enabledConfigs[msg.sender].add(account, ConfigId.unwrap(configId));
         emit IPolicy.PolicySet(configId, msg.sender, account);
     }
 
@@ -66,11 +56,11 @@ contract SudoPolicy is IUserOpPolicy, IActionPolicy, I1271Policy {
     }
 
     function check1271SignedAction(
-        ConfigId id,
-        address requestSender,
-        address account,
-        bytes32 hash,
-        bytes calldata signature
+        ConfigId /*id*/,
+        address /*requestSender*/,
+        address /*account*/,
+        bytes32 /*hash*/,
+        bytes calldata /*signature*/
     )
         external
         pure

--- a/contracts/external/policies/SudoPolicy.sol
+++ b/contracts/external/policies/SudoPolicy.sol
@@ -17,8 +17,7 @@ import { EnumerableSet } from "../../utils/EnumerableSet4337.sol";
 import { PackedUserOperation } from "modulekit/external/ERC4337.sol";
 
 contract SudoPolicy is IUserOpPolicy, IActionPolicy, I1271Policy {
-    
-        /**
+    /**
      * Initializes the policy to be used by given account through multiplexer (msg.sender) such as Smart Sessions.
      * Overwrites state.
      * @notice ATTENTION: This method is called during permission installation as part of the enabling policies flow.
@@ -56,10 +55,10 @@ contract SudoPolicy is IUserOpPolicy, IActionPolicy, I1271Policy {
     }
 
     function check1271SignedAction(
-        ConfigId /*id*/,
-        address /*requestSender*/,
-        address /*account*/,
-        bytes32 /*hash*/,
+        ConfigId, /*id*/
+        address, /*requestSender*/
+        address, /*account*/
+        bytes32, /*hash*/
         bytes calldata /*signature*/
     )
         external

--- a/foundry.toml
+++ b/foundry.toml
@@ -17,6 +17,7 @@
   cache_path  = "cache_forge"
   libs = ["node_modules", "lib"]
   gas_reports_ignore = ["LockTest"]
+  allow_internal_expect_revert = true
 
 [profile.ci]
   fuzz = { runs = 10_000 }

--- a/remappings.txt
+++ b/remappings.txt
@@ -10,7 +10,7 @@ solmate/=node_modules/solmate/src/
 account-abstraction/=node_modules/@ERC4337/account-abstraction/contracts/
 account-abstraction-v0.6/=node_modules/@ERC4337/account-abstraction-v0.6/contracts/
 
-@openzeppelin/=node_modules/@openzeppelin/contracts
+
 @safe-global/=node_modules/@safe-global/
 ds-test/=node_modules/ds-test/src/
 erc7579/=node_modules/erc7579/src/

--- a/test/utils/EnumerableSet.t.sol
+++ b/test/utils/EnumerableSet.t.sol
@@ -50,6 +50,17 @@ contract EnumerableSetTest is Test {
         assertTrue(values[0] == value2 || values[1] == value2);
     }
 
+    function test_Bytes32SetBulk() public {
+        for (uint256 i; i < 128; i++) {
+            bytes32Set.add(ACCOUNT, bytes32(uint256(i)));
+        }
+        assertEq(bytes32Set.length(ACCOUNT), 128);
+
+        bytes memory revertReason = abi.encodeWithSignature("AssociatedArray_OutOfBounds(uint256)", uint256(128));
+        vm.expectRevert(revertReason);
+        bytes32Set.add(ACCOUNT, bytes32(uint256(128)));
+    }
+
     function testBytes32RemoveAllBug() public {
         bytes32Set.add(ACCOUNT, bytes32(uint256(1)));
         bytes32Set.add(ACCOUNT, bytes32(uint256(2)));


### PR DESCRIPTION
SudoPolicy was storing configIds in an EnumerableSet4337 per multiplexer. That meant not more than 128 configIds can be set per account. 

It had two issues:
- No way of cleaning up this storage was introduced in the policy
- The configIds stored were never used for verification/validation

So I suggest removing the storage and its usage at onInstall.