### PR TITLE
Contract Whitelist Policy

### DIFF
--- a/contracts/external/policies/ContractWhitelistPolicy.sol
+++ b/contracts/external/policies/ContractWhitelistPolicy.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.23;
+
+import "../../DataTypes.sol";
+import { IActionPolicy, IPolicy, VALIDATION_SUCCESS, VALIDATION_FAILED } from "../../interfaces/IPolicy.sol";
+import { EnumerableSet } from "../../utils/EnumerableSet4337.sol";
+import { IERC165 } from "forge-std/interfaces/IERC165.sol";
+
+import { console2 } from "forge-std/console2.sol";
+/**
+ * @title ContractWhitelistPolicy | ActionPolicy
+ * @notice This policy checks if the target is whitelisted.
+ *         Should be used as a fallback action policy.
+ */
+contract ContractWhitelistPolicy is IPolicy, IActionPolicy {
+
+    error InvalidInitData();
+
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    mapping(ConfigId id => mapping(address msgSender => EnumerableSet.AddressSet targets)) internal whitelistedTargets;
+
+    /**
+     * @notice Checks if the action is within the valid time frame.
+     * @param id The config ID.
+     * @param account The account.
+     */
+    function checkAction(
+        ConfigId id,
+        address account,
+        address target,
+        uint256,
+        bytes calldata
+    )
+        external
+        view
+        returns (uint256)
+    {
+        if (whitelistedTargets[id][msg.sender].contains(account, target)) {
+            return VALIDATION_SUCCESS;
+        }
+        return VALIDATION_FAILED;
+    }
+
+    /**
+     * @notice Initializes the policy.
+     * Overwrites state.
+     * @notice ATTENTION: This method is called during permission installation as part of the enabling policies flow.
+     * A secure policy would minimize external calls from this method (ideally, to 0) to prevent passing control flow to
+     * external contracts.
+     * @param account The account.
+     * @param configId The config ID.
+     * @param initData The initialization data.
+     */
+    function initializeWithMultiplexer(address account, ConfigId configId, bytes calldata initData) external {
+        EnumerableSet.AddressSet storage $targets = whitelistedTargets[configId][msg.sender];
+        console2.log("initData.length", initData.length);
+        require(initData.length % 20 == 0 && initData.length > 0, InvalidInitData());
+        uint256 targetsLength = initData.length / 20;
+        for (uint256 i = 0; i < targetsLength; i++) {
+            address target = address(uint160(bytes20(initData[i * 20: (i + 1) * 20])));
+            require(target != address(0), InvalidInitData());
+            $targets.add(account, target);
+        }
+        emit IPolicy.PolicySet(configId, msg.sender, account);
+    }
+
+    /**
+     * @notice Returns the time frame config.
+     * @param id The config ID.
+     * @param multiplexer The multiplexer.
+     * @param smartAccount The smart account.
+     * @return The time frame config.
+     */
+    function isContractWhitelisted(
+        ConfigId id,
+        address multiplexer,
+        address smartAccount,
+        address target
+    )
+        external
+        view
+        returns (bool)
+    {
+        return whitelistedTargets[id][multiplexer].contains(smartAccount, target);
+    }
+
+    /**
+     * @notice Returns true if the interface is supported, false otherwise.
+     * @param interfaceID The interface ID.
+     * @return True if the interface is supported, false otherwise.
+     */
+    function supportsInterface(bytes4 interfaceID) external pure override returns (bool) {
+        return (
+            interfaceID == type(IERC165).interfaceId || interfaceID == type(IPolicy).interfaceId
+                || interfaceID == type(IActionPolicy).interfaceId
+        );
+    }
+}

--- a/contracts/external/policies/ContractWhitelistPolicy.sol
+++ b/contracts/external/policies/ContractWhitelistPolicy.sol
@@ -12,7 +12,6 @@ import { IERC165 } from "forge-std/interfaces/IERC165.sol";
  * @notice This policy checks if the target is whitelisted.
  *         Should be used as a fallback action policy.
  */
-
 contract ContractWhitelistPolicy is IPolicy, IActionPolicy {
     error InvalidInitData();
 
@@ -57,7 +56,10 @@ contract ContractWhitelistPolicy is IPolicy, IActionPolicy {
         require(initData.length % 20 == 0 && initData.length > 0, InvalidInitData());
         uint256 targetsLength = initData.length / 20;
         for (uint256 i = 0; i < targetsLength; i++) {
-            address target = address(uint160(bytes20(initData[i * 20:(i + 1) * 20])));
+            address target;
+            assembly {
+                target := shr(96, calldataload(add(initData.offset, mul(i, 0x14))))
+            }
             require(target != address(0), InvalidInitData());
             $targets.add(account, target);
         }

--- a/contracts/external/policies/ContractWhitelistPolicy.sol
+++ b/contracts/external/policies/ContractWhitelistPolicy.sol
@@ -7,14 +7,13 @@ import { IActionPolicy, IPolicy, VALIDATION_SUCCESS, VALIDATION_FAILED } from ".
 import { EnumerableSet } from "../../utils/EnumerableSet4337.sol";
 import { IERC165 } from "forge-std/interfaces/IERC165.sol";
 
-import { console2 } from "forge-std/console2.sol";
 /**
  * @title ContractWhitelistPolicy | ActionPolicy
  * @notice This policy checks if the target is whitelisted.
  *         Should be used as a fallback action policy.
  */
-contract ContractWhitelistPolicy is IPolicy, IActionPolicy {
 
+contract ContractWhitelistPolicy is IPolicy, IActionPolicy {
     error InvalidInitData();
 
     using EnumerableSet for EnumerableSet.AddressSet;
@@ -55,11 +54,10 @@ contract ContractWhitelistPolicy is IPolicy, IActionPolicy {
      */
     function initializeWithMultiplexer(address account, ConfigId configId, bytes calldata initData) external {
         EnumerableSet.AddressSet storage $targets = whitelistedTargets[configId][msg.sender];
-        console2.log("initData.length", initData.length);
         require(initData.length % 20 == 0 && initData.length > 0, InvalidInitData());
         uint256 targetsLength = initData.length / 20;
         for (uint256 i = 0; i < targetsLength; i++) {
-            address target = address(uint160(bytes20(initData[i * 20: (i + 1) * 20])));
+            address target = address(uint160(bytes20(initData[i * 20:(i + 1) * 20])));
             require(target != address(0), InvalidInitData());
             $targets.add(account, target);
         }

--- a/contracts/external/policies/SimpleGasPolicy.sol
+++ b/contracts/external/policies/SimpleGasPolicy.sol
@@ -19,7 +19,7 @@ contract SimpleGasPolicy is IUserOpPolicy {
         uint256 gasUsed;
     }
 
-    mapping(ConfigId id => mapping(address msgSender => mapping(address userOpSender => GasLimitConfig))) internal 
+    mapping(ConfigId id => mapping(address msgSender => mapping(address userOpSender => GasLimitConfig))) internal
         gasLimitConfigs;
 
     /**

--- a/test/mock/MockTarget.sol
+++ b/test/mock/MockTarget.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.23;
 
 contract MockTarget {
-
     event FallbackEvent(bytes4 sig);
 
     uint256 public value;
@@ -34,7 +33,7 @@ contract MockTarget {
         returnData = new bytes[](1);
     }
 
-    function fallback() external {
+    fallback() external {
         emit FallbackEvent(msg.sig);
     }
 }

--- a/test/mock/MockTarget.sol
+++ b/test/mock/MockTarget.sol
@@ -2,6 +2,9 @@
 pragma solidity ^0.8.23;
 
 contract MockTarget {
+
+    event FallbackEvent(bytes4 sig);
+
     uint256 public value;
 
     bytes32 public hash;
@@ -29,5 +32,9 @@ contract MockTarget {
         value = _value;
         hash = keccak256(callData);
         returnData = new bytes[](1);
+    }
+
+    function fallback() external {
+        emit FallbackEvent(msg.sig);
     }
 }

--- a/test/unit/base/PolicyTestBase.t.sol
+++ b/test/unit/base/PolicyTestBase.t.sol
@@ -98,6 +98,43 @@ contract PolicyTestBase is ERC1271TestBase {
         permissionId = smartSession.getPermissionId(session);
     }
 
+    function _enableFallbackActionSession(
+        address policy,
+        bytes memory initData,
+        AccountInstance memory instance,
+        bytes32 salt
+    )
+        internal
+        returns (PermissionId permissionId)
+    {
+        PolicyData[] memory policyDatas = new PolicyData[](1);
+        policyDatas[0] = PolicyData({ policy: policy, initData: initData });
+
+        ActionData[] memory actionDatas = new ActionData[](1);
+        actionDatas[0] = ActionData({
+            actionTarget: FALLBACK_TARGET_FLAG,
+            actionTargetSelector: FALLBACK_TARGET_SELECTOR_FLAG,
+            actionPolicies: policyDatas
+        });
+
+        Session memory session = Session({
+            sessionValidator: ISessionValidator(address(yesSessionValidator)),
+            salt: salt,
+            sessionValidatorInitData: "mockInitData",
+            userOpPolicies: new PolicyData[](0),
+            erc7739Policies: _getEmptyERC7739Data("Permit(bytes32 stuff)", new PolicyData[](0)),
+            actions: actionDatas,
+            permitERC4337Paymaster: true
+        });
+
+        Session[] memory enableSessionsArray = new Session[](1);
+        enableSessionsArray[0] = session;
+        vm.prank(instance.account);
+        smartSession.enableSessions(enableSessionsArray);
+
+        permissionId = smartSession.getPermissionId(session);
+    }
+
     function _enable1271Session(
         address policy,
         bytes memory initData,

--- a/test/unit/policies/ContractWhitelistPolicy.t.sol
+++ b/test/unit/policies/ContractWhitelistPolicy.t.sol
@@ -144,14 +144,17 @@ contract ContractWhitelistPolicyTest is PolicyTestBase {
             callData: callData,
             txValidator: address(smartSession)
         });
-        userOpData.userOp.signature = EncodeLib.encodeUse({ permissionId: permissionId_contractWhitelistAction, sig: hex"4141414141" });
+        userOpData.userOp.signature =
+            EncodeLib.encodeUse({ permissionId: permissionId_contractWhitelistAction, sig: hex"4141414141" });
 
         bytes memory expectedRevertReason = abi.encodeWithSelector(
             IEntryPoint.FailedOpWithRevert.selector,
             0,
             "AA23 reverted",
             abi.encodeWithSelector(
-                ISmartSession.PolicyViolation.selector, permissionId_contractWhitelistAction, address(contractWhitelistPolicy)
+                ISmartSession.PolicyViolation.selector,
+                permissionId_contractWhitelistAction,
+                address(contractWhitelistPolicy)
             )
         );
 

--- a/test/unit/policies/ContractWhitelistPolicy.t.sol
+++ b/test/unit/policies/ContractWhitelistPolicy.t.sol
@@ -1,0 +1,162 @@
+import "../../Base.t.sol";
+import "contracts/core/SmartSessionBase.sol";
+import "solady/utils/ECDSA.sol";
+import "contracts/lib/IdLib.sol";
+import "../base/PolicyTestBase.t.sol";
+import { ContractWhitelistPolicy } from "contracts/external/policies/ContractWhitelistPolicy.sol";
+
+contract ContractWhitelistPolicyTest is PolicyTestBase {
+    using IdLib for *;
+    using ModuleKitHelpers for *;
+    using ModuleKitUserOp for *;
+    using EncodeLib for PermissionId;
+
+    event FallbackEvent(bytes4 sig);
+
+    PermissionId permissionId_contractWhitelistAction;
+
+    ContractWhitelistPolicy contractWhitelistPolicy;
+
+    bytes contractWhitelistPolicyInitData;
+    address[] targets;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        contractWhitelistPolicy = new ContractWhitelistPolicy();
+
+        targets.push(_target);
+        contractWhitelistPolicyInitData = abi.encodePacked(_target);
+
+        for (uint256 i = 1; i < 10; i++) {
+            address newTarget = address(new MockTarget());
+            targets.push(newTarget);
+            contractWhitelistPolicyInitData = abi.encodePacked(contractWhitelistPolicyInitData, newTarget);
+        }
+        
+        permissionId_contractWhitelistAction = _enableFallbackActionSession(
+            address(contractWhitelistPolicy), contractWhitelistPolicyInitData, instance, keccak256("salt and pepper")
+        );
+        
+    }
+
+    function test_contractWhitelist_policy_init_reinit_use() public {
+        PermissionId permissionId = use_contractWhitelist_policy_success();
+        permissionId = use_contractWhitelist_policy_fail(permissionId);
+        reinit_contractWhitelist_policy(permissionId);
+    }
+
+    function test_contractWhitelist_policy_init_fails_with_invalid_init_data() public returns (PermissionId permissionId) {
+        bytes memory invalidInitData = abi.encodePacked(uint256(0));
+        vm.expectRevert(abi.encodeWithSelector(ContractWhitelistPolicy.InvalidInitData.selector));
+        _enableFallbackActionSession(address(contractWhitelistPolicy), invalidInitData, instance, keccak256("salt"));
+
+        invalidInitData = abi.encodePacked(targets[0], uint32(123123));
+        vm.expectRevert(abi.encodeWithSelector(ContractWhitelistPolicy.InvalidInitData.selector));
+        _enableFallbackActionSession(address(contractWhitelistPolicy), invalidInitData, instance, keccak256("salt"));
+
+        invalidInitData = abi.encodePacked(targets[0], targets[1], address(0), targets[2]);
+        vm.expectRevert(abi.encodeWithSelector(ContractWhitelistPolicy.InvalidInitData.selector));
+        _enableFallbackActionSession(address(contractWhitelistPolicy), invalidInitData, instance, keccak256("salt"));
+    }
+
+    function use_contractWhitelist_policy_success() public returns (PermissionId) {
+        PermissionId permissionId =
+            _enableFallbackActionSession(address(contractWhitelistPolicy), contractWhitelistPolicyInitData, instance, keccak256("salt"));
+        
+        bytes memory callData = abi.encodeCall(MockTarget.setValue, (1337));
+        // get userOp from ModuleKit
+        UserOpData memory userOpData =
+            instance.getExecOps({ target: _target, value: 0, callData: callData, txValidator: address(smartSession) });
+        
+        userOpData.userOp.signature = EncodeLib.encodeUse({ permissionId: permissionId, sig: hex"4141414141" });
+        
+        // execute userOp with modulekit
+        userOpData.execUserOps();
+        assertEq(target.value(), 1337);
+        return permissionId;
+    }
+
+    function use_contractWhitelist_policy_fail(PermissionId permissionId) public returns (PermissionId) {
+        uint256 valueToSet = 1338;
+        address noWhitelistedTarget = address(new MockTarget());
+        uint256 targetValueBefore = MockTarget(noWhitelistedTarget).value();
+
+        bytes memory callData = abi.encodeCall(MockTarget.setValue, (valueToSet));
+        UserOpData memory userOpData =
+            instance.getExecOps({ target: noWhitelistedTarget, value: 0, callData: callData, txValidator: address(smartSession) });
+        userOpData.userOp.signature = EncodeLib.encodeUse({ permissionId: permissionId, sig: hex"4141414141" });
+        vm.warp(block.timestamp + 11 minutes);
+
+        bytes memory expectedRevertReason = abi.encodeWithSelector(
+            IEntryPoint.FailedOpWithRevert.selector,
+            0,
+            "AA23 reverted",
+            abi.encodeWithSelector(ISmartSession.PolicyViolation.selector, permissionId, address(contractWhitelistPolicy))
+        );
+
+        // this should revert as the limit has been reached
+        vm.expectRevert(expectedRevertReason);
+        userOpData.execUserOps();
+        assertEq(MockTarget(noWhitelistedTarget).value(), targetValueBefore);
+        return permissionId;
+    }
+
+    function reinit_contractWhitelist_policy(PermissionId permissionId) public {
+        address newTarget = address(new MockTarget());
+        targets.push(newTarget);
+        bytes memory newContractWhitelistPolicyInitData = abi.encodePacked(contractWhitelistPolicyInitData, newTarget);
+        PermissionId permissionIdReInited =
+            _enableFallbackActionSession(address(contractWhitelistPolicy), newContractWhitelistPolicyInitData, instance, keccak256("salt"));
+        assertEq(PermissionId.unwrap(permissionIdReInited), PermissionId.unwrap(permissionId));
+        
+        bool isWhitelisted;
+
+        for (uint256 i; i < targets.length; i++) {
+            isWhitelisted = contractWhitelistPolicy.isContractWhitelisted(
+                IdLib.toConfigId({
+                    permissionId: permissionIdReInited,
+                    actionId: FALLBACK_ACTIONID,
+                    account: instance.account
+                }),
+                address(smartSession),
+                instance.account,
+                targets[i]
+            );
+            assertTrue(isWhitelisted);
+        }
+    }
+
+
+    //test as action policy
+    function test_use_timeframe_policy_as_Action_policy_success(uint256 seed) public returns (PermissionId permissionId) {
+        // remove last target from targets as it was not enabled in the setUp()
+        targets.pop();
+
+        bytes4 randomSelector = bytes4(keccak256(abi.encodePacked(seed)));
+        for (uint256 i; i < targets.length; i++) {
+            address currentTarget = targets[i];
+            bytes memory callData = abi.encodeWithSelector(randomSelector);
+            UserOpData memory userOpData = instance.getExecOps({ target: currentTarget, value: 0, callData: callData, txValidator: address(smartSession) });
+            userOpData.userOp.signature = EncodeLib.encodeUse({ permissionId: permissionId_contractWhitelistAction, sig: hex"4141414141" });
+            vm.expectEmit(true, true, true, true, currentTarget);
+            emit FallbackEvent(randomSelector);
+            userOpData.execUserOps();
+        }
+    }
+
+    //test as action policy
+/*     function test_use_timeframe_policy_as_Action_policy_fail() public returns (PermissionId permissionId) {
+        bytes memory callData = abi.encodeCall(MockTarget.setValue, (1337));
+        UserOpData memory userOpData =
+            instance.getExecOps({ target: _target, value: 0, callData: callData, txValidator: address(smartSession) });
+        userOpData.userOp.signature =
+            EncodeLib.encodeUse({ permissionId: permissionId_timeframedAction, sig: hex"4141414141" });
+        vm.warp(block.timestamp + 11 minutes);
+        bytes memory expectedRevertReason =
+            abi.encodeWithSelector(IEntryPoint.FailedOp.selector, 0, "AA22 expired or not due");
+        vm.expectRevert(expectedRevertReason);
+        userOpData.execUserOps();
+        assertEq(target.value(), 0);
+    } */
+}


### PR DESCRIPTION
Policy that should be used as a fallback action policy and allows whitelisting all the selectors for a given smart contract.